### PR TITLE
MM-26438 Changes to sync with database factory vertical scaling deployment

### DIFF
--- a/terraform/aws/database-factory/main.tf
+++ b/terraform/aws/database-factory/main.tf
@@ -1,8 +1,6 @@
 terraform {
   required_version = ">= 0.12"
   backend "s3" {
-    # bucket = "terraform-cloud-monitoring-state-bucket-dev"
-    # key    = "mattermost-network-provisioning-rds"
     region = "us-east-1"
   }
 }

--- a/terraform/aws/database-factory/variables.tf
+++ b/terraform/aws/database-factory/variables.tf
@@ -116,13 +116,13 @@ variable "replica_scale_min" {
 }
 
 variable "replica_min" {
-  default     = 2
+  default     = 3
   type        = number
   description = "Number of replicas to deploy initially with the RDS Cluster."
 }
 
 variable "predefined_metric_type" {
-  default = "RDSReaderAverageCPUUtilization"
+  default = "RDSReaderAverageDatabaseConnections"
   type    = string
 }
 
@@ -133,8 +133,8 @@ variable "replica_scale_cpu" {
 }
 
 variable "replica_scale_connections" {
-  default     = ""
-  type        = string
+  default     = 10000
+  type        = number
   description = "Needs to be set when predefined_metric_type is RDSReaderAverageDatabaseConnections"
 }
 

--- a/terraform/aws/modules/rds-aurora/main.tf
+++ b/terraform/aws/modules/rds-aurora/main.tf
@@ -151,3 +151,41 @@ resource "aws_secretsmanager_secret_version" "master_password" {
   secret_id     = aws_secretsmanager_secret.master_password.id
   secret_string = local.master_password
 }
+
+data "aws_sns_topic" "horizontal_scaling_sns_topic" {
+  name = "cloud-db-factory-vertical-scaling-${var.environment}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "db_instances_alarm_cpu" {
+  count                     = var.replica_min
+  alarm_name                = format("rds-db-instance-multitenant-%s-%s-%s-cpu", split("-", var.vpc_id)[1], local.database_id, (count.index + 1))
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "3"
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/RDS"
+  period                    = "600"
+  statistic                 = "Average"
+  threshold                 = "70"
+  alarm_description         = "This metric monitors RDS DB Instance cpu utilization"
+  actions_enabled           = true  
+  alarm_actions             = [data.aws_sns_topic.horizontal_scaling_sns_topic.arn]
+  dimensions                = {DBInstanceIdentifier = aws_rds_cluster_instance.provisioning_rds_db_instance[count.index].identifier}
+}
+
+resource "aws_cloudwatch_metric_alarm" "db_instances_alarm_memory" {
+  count                     = var.replica_min
+  alarm_name                = format("rds-db-instance-multitenant-%s-%s-%s-memory", split("-", var.vpc_id)[1], local.database_id, (count.index + 1))
+  comparison_operator       = "LessThanOrEqualToThreshold"
+  evaluation_periods        = "3"
+  metric_name               = "FreeableMemory"
+  namespace                 = "AWS/RDS"
+  period                    = "600"
+  statistic                 = "Average"
+  threshold                 = "100000000"
+  alarm_description         = "This metric monitors RDS DB Instance freeable memory"
+  actions_enabled           = true  
+  alarm_actions             = [data.aws_sns_topic.horizontal_scaling_sns_topic.arn]
+  dimensions                = {DBInstanceIdentifier = aws_rds_cluster_instance.provisioning_rds_db_instance[count.index].identifier}
+}
+
+


### PR DESCRIPTION
#### Summary
-  Adding additional reader
- Updating autoscaling policy to track number of connections
- Adding CW alarms for CPU and Memory metrics for each Cluster DB instance

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26438

#### Release Note

```release-note
- Adding additional reader
- Updating autoscaling policy to track number of connections
- Adding CW alarms for CPU and Memory metrics for each Cluster DB instance
```
