### PR TITLE
[MM 27340] Add database factory PostgreSQL support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DOCKER_BUILD_IMAGE = golang:1.14.1
 DOCKER_BASE_IMAGE = alpine:3.11
 
 ## Tool Versions
-TERRAFORM_VERSION=0.12.28
+TERRAFORM_VERSION=0.12.29
 
 ################################################################################
 

--- a/api/api.go
+++ b/api/api.go
@@ -21,11 +21,11 @@ func initCluster(apiRouter *mux.Router, context *Context) {
 		return newContextHandler(context, handler)
 	}
 
-	clustersRouter := apiRouter.PathPrefix("/create").Subrouter()
-	clustersRouter.Handle("", addContext(handleCreateDBCluster)).Methods("POST")
+	clustersRouter := apiRouter.PathPrefix("/provision").Subrouter()
+	clustersRouter.Handle("", addContext(handleProvisionDBCluster)).Methods("POST")
 }
 
-// handleCreateDBCluster responds to POST /api/create, beginning the process of creating a new RDS Aurora cluster.
+// handleProvisionDBCluster responds to POST /api/provision, beginning the process of creating a new RDS Aurora cluster.
 // sample body:
 // {
 //     "vpcID": "vpc-12345678",
@@ -39,8 +39,8 @@ func initCluster(apiRouter *mux.Router, context *Context) {
 //     "maxConnections": "150000"
 //     "replicas": "3"
 // }
-func handleCreateDBCluster(c *Context, w http.ResponseWriter, r *http.Request) {
-	createClusterRequest, err := model.NewCreateClusterRequestFromReader(r.Body)
+func handleProvisionDBCluster(c *Context, w http.ResponseWriter, r *http.Request) {
+	provisionClusterRequest, err := model.NewProvisionClusterRequestFromReader(r.Body)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to decode request")
 		w.WriteHeader(http.StatusBadRequest)
@@ -48,19 +48,19 @@ func handleCreateDBCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	cluster := model.Cluster{
-		VPCID:                 createClusterRequest.VPCID,
-		ClusterID:             createClusterRequest.ClusterID,
-		Environment:           createClusterRequest.Environment,
-		StateStore:            createClusterRequest.StateStore,
-		Apply:                 createClusterRequest.Apply,
-		InstanceType:          createClusterRequest.InstanceType,
-		BackupRetentionPeriod: createClusterRequest.BackupRetentionPeriod,
-		DBEngine:              createClusterRequest.DBEngine,
-		MaxConnections:        createClusterRequest.MaxConnections,
-		Replicas:              createClusterRequest.Replicas,
+		VPCID:                 provisionClusterRequest.VPCID,
+		ClusterID:             provisionClusterRequest.ClusterID,
+		Environment:           provisionClusterRequest.Environment,
+		StateStore:            provisionClusterRequest.StateStore,
+		Apply:                 provisionClusterRequest.Apply,
+		InstanceType:          provisionClusterRequest.InstanceType,
+		BackupRetentionPeriod: provisionClusterRequest.BackupRetentionPeriod,
+		DBEngine:              provisionClusterRequest.DBEngine,
+		MaxConnections:        provisionClusterRequest.MaxConnections,
+		Replicas:              provisionClusterRequest.Replicas,
 	}
 
-	go dbfactory.InitCreateCluster(&cluster)
+	go dbfactory.InitProvisionCluster(&cluster)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)

--- a/api/api.go
+++ b/api/api.go
@@ -34,7 +34,10 @@ func initCluster(apiRouter *mux.Router, context *Context) {
 //     "apply": true,
 //     "instanceType": "db.r5.large",
 //     "clusterID": "12345678",
-//     "backupRetentionPeriod": "15"
+//     "backupRetentionPeriod": "15",
+//     "dbEngine: postgresql",
+//     "maxConnections": "150000"
+//     "replicas": "3"
 // }
 func handleCreateDBCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 	createClusterRequest, err := model.NewCreateClusterRequestFromReader(r.Body)
@@ -52,6 +55,9 @@ func handleCreateDBCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 		Apply:                 createClusterRequest.Apply,
 		InstanceType:          createClusterRequest.InstanceType,
 		BackupRetentionPeriod: createClusterRequest.BackupRetentionPeriod,
+		DBEngine:              createClusterRequest.DBEngine,
+		MaxConnections:        createClusterRequest.MaxConnections,
+		Replicas:              createClusterRequest.Replicas,
 	}
 
 	go dbfactory.InitCreateCluster(&cluster)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateCluster(t *testing.T) {
+func TestProvisionCluster(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 
 	router := mux.NewRouter()
@@ -27,19 +27,19 @@ func TestCreateCluster(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	t.Run("invalid payload", func(t *testing.T) {
-		resp, err := http.Post(fmt.Sprintf("%s/api/create", ts.URL), "application/json", bytes.NewReader([]byte("invalid")))
+		resp, err := http.Post(fmt.Sprintf("%s/api/provision", ts.URL), "application/json", bytes.NewReader([]byte("invalid")))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
 	t.Run("empty payload", func(t *testing.T) {
-		resp, err := http.Post(fmt.Sprintf("%s/api/create", ts.URL), "application/json", bytes.NewReader([]byte("")))
+		resp, err := http.Post(fmt.Sprintf("%s/api/provision", ts.URL), "application/json", bytes.NewReader([]byte("")))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
 	t.Run("empty vpc id", func(t *testing.T) {
-		_, err := client.CreateCluster(&model.CreateClusterRequest{
+		_, err := client.ProvisionCluster(&model.ProvisionClusterRequest{
 			VPCID:                 "",
 			ClusterID:             "12345678",
 			Environment:           "test",
@@ -54,7 +54,7 @@ func TestCreateCluster(t *testing.T) {
 	})
 
 	t.Run("empty environment", func(t *testing.T) {
-		_, err := client.CreateCluster(&model.CreateClusterRequest{
+		_, err := client.ProvisionCluster(&model.ProvisionClusterRequest{
 			VPCID:                 "vpc-12345678",
 			ClusterID:             "12345678",
 			Environment:           "",
@@ -69,7 +69,7 @@ func TestCreateCluster(t *testing.T) {
 	})
 
 	t.Run("empty state store", func(t *testing.T) {
-		_, err := client.CreateCluster(&model.CreateClusterRequest{
+		_, err := client.ProvisionCluster(&model.ProvisionClusterRequest{
 			VPCID:                 "vpc-12345678",
 			ClusterID:             "12345678",
 			Environment:           "test",
@@ -84,7 +84,7 @@ func TestCreateCluster(t *testing.T) {
 	})
 
 	t.Run("valid", func(t *testing.T) {
-		cluster, err := client.CreateCluster(&model.CreateClusterRequest{
+		cluster, err := client.ProvisionCluster(&model.ProvisionClusterRequest{
 			VPCID:                 "vpc-12345678",
 			ClusterID:             "12345678",
 			Environment:           "test",

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -46,6 +46,9 @@ func TestCreateCluster(t *testing.T) {
 			StateStore:            "testbucket",
 			Apply:                 false,
 			BackupRetentionPeriod: "15",
+			DBEngine:              "postgresql",
+			MaxConnections:        "150000",
+			Replicas:              "3",
 		})
 		require.EqualError(t, err, "failed with status code 400")
 	})
@@ -58,6 +61,9 @@ func TestCreateCluster(t *testing.T) {
 			StateStore:            "testbucket",
 			Apply:                 false,
 			BackupRetentionPeriod: "15",
+			DBEngine:              "postgresql",
+			MaxConnections:        "150000",
+			Replicas:              "3",
 		})
 		require.EqualError(t, err, "failed with status code 400")
 	})
@@ -70,6 +76,9 @@ func TestCreateCluster(t *testing.T) {
 			StateStore:            "",
 			Apply:                 false,
 			BackupRetentionPeriod: "15",
+			DBEngine:              "postgresql",
+			MaxConnections:        "150000",
+			Replicas:              "3",
 		})
 		require.EqualError(t, err, "failed with status code 400")
 	})
@@ -83,6 +92,9 @@ func TestCreateCluster(t *testing.T) {
 			Apply:                 false,
 			InstanceType:          "test-type",
 			BackupRetentionPeriod: "16",
+			DBEngine:              "mysql",
+			MaxConnections:        "100000",
+			Replicas:              "2",
 		})
 		require.NoError(t, err)
 		require.Equal(t, "vpc-12345678", cluster.VPCID)
@@ -92,5 +104,8 @@ func TestCreateCluster(t *testing.T) {
 		require.Equal(t, false, cluster.Apply)
 		require.Equal(t, "test-type", cluster.InstanceType)
 		require.Equal(t, "16", cluster.BackupRetentionPeriod)
+		require.Equal(t, "mysql", cluster.DBEngine)
+		require.Equal(t, "100000", cluster.MaxConnections)
+		require.Equal(t, "2", cluster.Replicas)
 	})
 }

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@ LABEL name="Mattermost Cloud Database Factory" \
   distribution-scope="public" \
   architecture="x86_64" \
   url="https://mattermost.com" \
-  io.k8s.description="Mattermost Cloud Database Factory creates and configures RDS Aurora Clusters" \
+  io.k8s.description="Mattermost Cloud Database Factory provisions and configures RDS Aurora Clusters" \
   io.k8s.display-name="Mattermost Cloud Database Factory"
 
 ENV CLOUD=/mattermost-cloud-database-factory/dbfactory \

--- a/cmd/dbfactory/cluster.go
+++ b/cmd/dbfactory/cluster.go
@@ -12,18 +12,18 @@ import (
 func init() {
 	clusterCmd.PersistentFlags().String("server", "http://localhost:8077", "The DB factory server whose API will be queried.")
 
-	clusterCreateCmd.Flags().String("vpc-id", "", "The VPC id to create a RDS Aurora Cluster")
-	clusterCreateCmd.Flags().String("cluster-id", "", "A random 8 character identifier of the Aurora cluster")
-	clusterCreateCmd.Flags().String("environment", "dev", "The environment used for the deployment. Can be dev, test, staging or prod")
-	clusterCreateCmd.Flags().String("state-store", "terraform-database-factory-state-bucket-dev", "The s3 bucket to store the terraform state")
-	clusterCreateCmd.Flags().Bool("apply", false, "If disabled, only a Terraform plan will run instead of Terraform apply")
-	clusterCreateCmd.Flags().String("instance-type", "db.r5.large", "The instance type used for Aurora cluster replicas")
-	clusterCreateCmd.Flags().String("backup-retention-period", "15", "The retention period for the DB instance backups")
-	clusterCreateCmd.Flags().String("db-engine", "postgresql", "The database engine. Can be mysql or postgresql")
-	clusterCreateCmd.Flags().String("max-connections", "auto", "The max connections allowed in the DB cluster. This is applicable only to PostgreSQL engine")
-	clusterCreateCmd.Flags().String("replicas", "3", "The total number of write/read replicas.")
+	clusterProvisionCmd.Flags().String("vpc-id", "", "The VPC id to provision a RDS Aurora Cluster")
+	clusterProvisionCmd.Flags().String("cluster-id", "", "A random 8 character identifier of the Aurora cluster")
+	clusterProvisionCmd.Flags().String("environment", "dev", "The environment used for the deployment. Can be dev, test, staging or prod")
+	clusterProvisionCmd.Flags().String("state-store", "terraform-database-factory-state-bucket-dev", "The s3 bucket to store the terraform state")
+	clusterProvisionCmd.Flags().Bool("apply", false, "If disabled, only a Terraform plan will run instead of Terraform apply")
+	clusterProvisionCmd.Flags().String("instance-type", "db.r5.large", "The instance type used for Aurora cluster replicas")
+	clusterProvisionCmd.Flags().String("backup-retention-period", "15", "The retention period for the DB instance backups")
+	clusterProvisionCmd.Flags().String("db-engine", "postgresql", "The database engine. Can be mysql or postgresql")
+	clusterProvisionCmd.Flags().String("max-connections", "auto", "The max connections allowed in the DB cluster. This is applicable only to PostgreSQL engine")
+	clusterProvisionCmd.Flags().String("replicas", "3", "The total number of write/read replicas.")
 
-	clusterCmd.AddCommand(clusterCreateCmd)
+	clusterCmd.AddCommand(clusterProvisionCmd)
 }
 
 var clusterCmd = &cobra.Command{
@@ -31,9 +31,9 @@ var clusterCmd = &cobra.Command{
 	Short: "Manipulate RDS clusters managed by the database factory server.",
 }
 
-var clusterCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create a RDS Aurora cluster.",
+var clusterProvisionCmd = &cobra.Command{
+	Use:   "provision",
+	Short: "Provision a RDS Aurora cluster.",
 	RunE: func(command *cobra.Command, args []string) error {
 		command.SilenceUsage = true
 		serverAddress, _ := command.Flags().GetString("server")
@@ -50,7 +50,7 @@ var clusterCreateCmd = &cobra.Command{
 		maxConnections, _ := command.Flags().GetString("max-connections")
 		replicas, _ := command.Flags().GetString("replicas")
 
-		cluster, err := client.CreateCluster(&model.CreateClusterRequest{
+		cluster, err := client.ProvisionCluster(&model.ProvisionClusterRequest{
 			VPCID:                 vpcID,
 			ClusterID:             clusterID,
 			Environment:           environment,
@@ -63,7 +63,7 @@ var clusterCreateCmd = &cobra.Command{
 			Replicas:              replicas,
 		})
 		if err != nil {
-			return errors.Wrap(err, "failed to create RDS cluster")
+			return errors.Wrap(err, "failed to provision RDS cluster")
 		}
 		err = printJSON(cluster)
 		if err != nil {

--- a/cmd/dbfactory/cluster.go
+++ b/cmd/dbfactory/cluster.go
@@ -17,8 +17,11 @@ func init() {
 	clusterCreateCmd.Flags().String("environment", "dev", "The environment used for the deployment. Can be dev, test, staging or prod")
 	clusterCreateCmd.Flags().String("state-store", "terraform-database-factory-state-bucket-dev", "The s3 bucket to store the terraform state")
 	clusterCreateCmd.Flags().Bool("apply", false, "If disabled, only a Terraform plan will run instead of Terraform apply")
-	clusterCreateCmd.Flags().String("instance-type", "db.r4.large", "The instance type used for Aurora cluster replicas")
+	clusterCreateCmd.Flags().String("instance-type", "db.r5.large", "The instance type used for Aurora cluster replicas")
 	clusterCreateCmd.Flags().String("backup-retention-period", "15", "The retention period for the DB instance backups")
+	clusterCreateCmd.Flags().String("db-engine", "postgresql", "The database engine. Can be mysql or postgresql")
+	clusterCreateCmd.Flags().String("max-connections", "auto", "The max connections allowed in the DB cluster. This is applicable only to PostgreSQL engine")
+	clusterCreateCmd.Flags().String("replicas", "3", "The total number of write/read replicas.")
 
 	clusterCmd.AddCommand(clusterCreateCmd)
 }
@@ -43,6 +46,9 @@ var clusterCreateCmd = &cobra.Command{
 		apply, _ := command.Flags().GetBool("apply")
 		instanceType, _ := command.Flags().GetString("instance-type")
 		backupRetentionPeriod, _ := command.Flags().GetString("backup-retention-period")
+		dbEngine, _ := command.Flags().GetString("db-engine")
+		maxConnections, _ := command.Flags().GetString("max-connections")
+		replicas, _ := command.Flags().GetString("replicas")
 
 		cluster, err := client.CreateCluster(&model.CreateClusterRequest{
 			VPCID:                 vpcID,
@@ -52,6 +58,9 @@ var clusterCreateCmd = &cobra.Command{
 			Apply:                 apply,
 			InstanceType:          instanceType,
 			BackupRetentionPeriod: backupRetentionPeriod,
+			DBEngine:              dbEngine,
+			MaxConnections:        maxConnections,
+			Replicas:              replicas,
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to create RDS cluster")

--- a/database-factory/dbfactory.go
+++ b/database-factory/dbfactory.go
@@ -12,9 +12,9 @@ import (
 var templateDirMySQL = "terraform/aws/database-factory"
 var templateDirPostgreSQL = "terraform/aws/database-factory-postgresql"
 
-// InitCreateCluster is used to call the CreateCluster function.
-func InitCreateCluster(cluster *model.Cluster) {
-	err := CreateCluster(cluster)
+// InitProvisionCluster is used to call the ProvisionCluster function.
+func InitProvisionCluster(cluster *model.Cluster) {
+	err := ProvisionCluster(cluster)
 	if err != nil {
 		logger.WithError(err).Error("failed to deploy RDS Aurora cluster")
 		err = sendMattermostErrorNotification(cluster, err, "The Database Factory failed to deploy RDS Aurora cluster")
@@ -25,8 +25,8 @@ func InitCreateCluster(cluster *model.Cluster) {
 	}
 }
 
-// CreateCluster is used to initiate Terraform and either Apply or Plan Terraform for the RDS Cluster deployments.
-func CreateCluster(cluster *model.Cluster) error {
+// ProvisionCluster is used to initiate Terraform and either Apply or Plan Terraform for the RDS Cluster deployments.
+func ProvisionCluster(cluster *model.Cluster) error {
 	logger.Info("Initialising Terraform")
 	stateObject := fmt.Sprintf("rds-cluster-multitenant-%s-%s", strings.Split(cluster.VPCID, "-")[1], cluster.ClusterID)
 

--- a/database-factory/dbfactory.go
+++ b/database-factory/dbfactory.go
@@ -9,7 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-var templateDir = "terraform/aws/database-factory"
+var templateDirMySQL = "terraform/aws/database-factory"
+var templateDirPostgreSQL = "terraform/aws/database-factory-postgresql"
 
 // InitCreateCluster is used to call the CreateCluster function.
 func InitCreateCluster(cluster *model.Cluster) {
@@ -28,6 +29,13 @@ func InitCreateCluster(cluster *model.Cluster) {
 func CreateCluster(cluster *model.Cluster) error {
 	logger.Info("Initialising Terraform")
 	stateObject := fmt.Sprintf("rds-cluster-multitenant-%s-%s", strings.Split(cluster.VPCID, "-")[1], cluster.ClusterID)
+
+	var templateDir string
+	if cluster.DBEngine == "mysql" {
+		templateDir = templateDirMySQL
+	} else {
+		templateDir = templateDirPostgreSQL
+	}
 
 	tf, err := terraform.New(templateDir, cluster.StateStore, logger)
 	if err != nil {

--- a/database-factory/notification.go
+++ b/database-factory/notification.go
@@ -40,6 +40,9 @@ func sendMattermostNotification(cluster *model.Cluster, message string) error {
 			{Title: "InstanceType", Value: cluster.InstanceType, Short: true},
 			{Title: "BackupRetentionPeriod", Value: cluster.BackupRetentionPeriod, Short: true},
 			{Title: "ClusterID", Value: cluster.ClusterID, Short: true},
+			{Title: "DBEngine", Value: cluster.DBEngine, Short: true},
+			{Title: "MaxConnections", Value: cluster.MaxConnections, Short: true},
+			{Title: "Replicas", Value: cluster.Replicas, Short: true},
 		},
 	}
 
@@ -68,6 +71,9 @@ func sendMattermostErrorNotification(cluster *model.Cluster, errorMessage error,
 			{Title: "InstanceType", Value: cluster.InstanceType, Short: true},
 			{Title: "BackupRetentionPeriod", Value: cluster.BackupRetentionPeriod, Short: true},
 			{Title: "ClusterID", Value: cluster.ClusterID, Short: true},
+			{Title: "DBEngine", Value: cluster.DBEngine, Short: true},
+			{Title: "MaxConnections", Value: cluster.MaxConnections, Short: true},
+			{Title: "Replicas", Value: cluster.Replicas, Short: true},
 		},
 	}
 

--- a/internal/tools/terraform/plan.go
+++ b/internal/tools/terraform/plan.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	// "io/ioutil"
 	// "path"
@@ -36,7 +37,11 @@ func (c *Cmd) Init(remoteKey string) error {
 
 // Plan invokes terraform Plan.
 func (c *Cmd) Plan(cluster *model.Cluster) error {
-	_, _, err := c.run(
+	replicas, err := strconv.Atoi(cluster.Replicas)
+	if err != nil {
+		return errors.Wrap(err, "failed to transform replicas string to integer")
+	}
+	_, _, err = c.run(
 		"plan",
 		arg("input", "false"),
 		arg("var", fmt.Sprintf("vpc_id=%s", cluster.VPCID)),
@@ -44,6 +49,8 @@ func (c *Cmd) Plan(cluster *model.Cluster) error {
 		arg("var", fmt.Sprintf("environment=%s", cluster.Environment)),
 		arg("var", fmt.Sprintf("instance_type=%s", cluster.InstanceType)),
 		arg("var", fmt.Sprintf("backup_retention_period=%s", cluster.BackupRetentionPeriod)),
+		arg("var", fmt.Sprintf("max_postgresql_connections=%s", cluster.MaxConnections)),
+		arg("var", fmt.Sprintf("replica_min=%d", replicas)),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to invoke terraform plan")
@@ -54,7 +61,11 @@ func (c *Cmd) Plan(cluster *model.Cluster) error {
 
 // Apply invokes terraform apply.
 func (c *Cmd) Apply(cluster *model.Cluster) error {
-	_, _, err := c.run(
+	replicas, err := strconv.Atoi(cluster.Replicas)
+	if err != nil {
+		return errors.Wrap(err, "failed to transform replicas string to integer")
+	}
+	_, _, err = c.run(
 		"apply",
 		arg("input", "false"),
 		arg("var", fmt.Sprintf("vpc_id=%s", cluster.VPCID)),
@@ -62,6 +73,8 @@ func (c *Cmd) Apply(cluster *model.Cluster) error {
 		arg("var", fmt.Sprintf("environment=%s", cluster.Environment)),
 		arg("var", fmt.Sprintf("instance_type=%s", cluster.InstanceType)),
 		arg("var", fmt.Sprintf("backup_retention_period=%s", cluster.BackupRetentionPeriod)),
+		arg("var", fmt.Sprintf("max_postgresql_connections=%s", cluster.MaxConnections)),
+		arg("var", fmt.Sprintf("replica_min=%d", replicas)),
 		arg("auto-approve"),
 	)
 	if err != nil {

--- a/model/client.go
+++ b/model/client.go
@@ -56,9 +56,9 @@ func (c *Client) doPost(u string, request interface{}) (*http.Response, error) {
 	return c.httpClient.Do(req)
 }
 
-// CreateCluster requests the creation of a RDS cluster from the configured provisioning server.
-func (c *Client) CreateCluster(request *CreateClusterRequest) (*Cluster, error) {
-	resp, err := c.doPost(c.buildURL("/api/create"), request)
+// ProvisionCluster requests the creation of a RDS cluster from the configured provisioning server.
+func (c *Client) ProvisionCluster(request *ProvisionClusterRequest) (*Cluster, error) {
+	resp, err := c.doPost(c.buildURL("/api/provision"), request)
 	if err != nil {
 		return nil, err
 	}

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -14,6 +14,9 @@ type Cluster struct {
 	Apply                 bool
 	InstanceType          string
 	BackupRetentionPeriod string
+	DBEngine              string
+	MaxConnections        string
+	Replicas              string
 }
 
 // ClusterFromReader decodes a json-encoded cluster from the given io.Reader.

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -8,8 +8,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CreateClusterRequest specifies the parameters for a new cluster.
-type CreateClusterRequest struct {
+// ProvisionClusterRequest specifies the parameters for a new cluster.
+type ProvisionClusterRequest struct {
 	VPCID                 string `json:"vpcID,omitempty"`
 	ClusterID             string `json:"clusterID,omitempty"`
 	Environment           string `json:"environment,omitempty"`
@@ -22,25 +22,25 @@ type CreateClusterRequest struct {
 	Replicas              string `json:"replicas"`
 }
 
-// NewCreateClusterRequestFromReader decodes the request and returns after validation and setting the defaults.
-func NewCreateClusterRequestFromReader(reader io.Reader) (*CreateClusterRequest, error) {
-	var createClusterRequest CreateClusterRequest
-	err := json.NewDecoder(reader).Decode(&createClusterRequest)
+// NewProvisionClusterRequestFromReader decodes the request and returns after validation and setting the defaults.
+func NewProvisionClusterRequestFromReader(reader io.Reader) (*ProvisionClusterRequest, error) {
+	var provisionClusterRequest ProvisionClusterRequest
+	err := json.NewDecoder(reader).Decode(&provisionClusterRequest)
 	if err != nil && err != io.EOF {
-		return nil, errors.Wrap(err, "failed to decode create cluster request")
+		return nil, errors.Wrap(err, "failed to decode provision cluster request")
 	}
 
-	err = createClusterRequest.Validate()
+	err = provisionClusterRequest.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "create cluster request failed validation")
+		return nil, errors.Wrap(err, "provision cluster request failed validation")
 	}
-	createClusterRequest.SetDefaults()
+	provisionClusterRequest.SetDefaults()
 
-	return &createClusterRequest, nil
+	return &provisionClusterRequest, nil
 }
 
-// Validate validates the values of a cluster create request.
-func (request *CreateClusterRequest) Validate() error {
+// Validate validates the values of a cluster provision request.
+func (request *ProvisionClusterRequest) Validate() error {
 	if request.VPCID == "" {
 		return errors.Errorf("vpc id cannot be empty")
 	}
@@ -56,8 +56,8 @@ func (request *CreateClusterRequest) Validate() error {
 	return nil
 }
 
-// SetDefaults sets the default values for a cluster create request.
-func (request *CreateClusterRequest) SetDefaults() {
+// SetDefaults sets the default values for a cluster provision request.
+func (request *ProvisionClusterRequest) SetDefaults() {
 	if request.ClusterID == "" {
 		request.ClusterID = StringWithCharset(8, strings.Split(request.VPCID, "-")[1])
 	}

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -11,12 +11,15 @@ import (
 // CreateClusterRequest specifies the parameters for a new cluster.
 type CreateClusterRequest struct {
 	VPCID                 string `json:"vpcID,omitempty"`
-	ClusterID             string `json:"ClusterID,omitempty"`
+	ClusterID             string `json:"clusterID,omitempty"`
 	Environment           string `json:"environment,omitempty"`
 	StateStore            string `json:"stateStore,omitempty"`
 	Apply                 bool   `json:"apply,omitempty"`
 	InstanceType          string `json:"instanceType"`
 	BackupRetentionPeriod string `json:"backupRetentionPeriod"`
+	DBEngine              string `json:"dbEngine"`
+	MaxConnections        string `json:"maxConnections,omitempty"`
+	Replicas              string `json:"replicas"`
 }
 
 // NewCreateClusterRequestFromReader decodes the request and returns after validation and setting the defaults.
@@ -60,10 +63,22 @@ func (request *CreateClusterRequest) SetDefaults() {
 	}
 
 	if request.InstanceType == "" {
-		request.InstanceType = "db.r4.large"
+		request.InstanceType = "db.r5.large"
 	}
 
 	if request.BackupRetentionPeriod == "" {
 		request.BackupRetentionPeriod = "15"
+	}
+
+	if request.DBEngine == "" {
+		request.DBEngine = "postgresql"
+	}
+
+	if request.MaxConnections == "" {
+		request.MaxConnections = "auto"
+	}
+
+	if request.Replicas == "" {
+		request.Replicas = "3"
 	}
 }

--- a/model/cluster_request_test.go
+++ b/model/cluster_request_test.go
@@ -7,15 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateClusterRequestValid(t *testing.T) {
+func TestProvisionClusterRequestValid(t *testing.T) {
 	var testCases = []struct {
 		testName     string
-		request      *model.CreateClusterRequest
+		request      *model.ProvisionClusterRequest
 		requireError bool
 	}{
-		{"invalid vpcid", &model.CreateClusterRequest{VPCID: ""}, true},
-		{"invalid environment", &model.CreateClusterRequest{Environment: ""}, true},
-		{"invalid statestore", &model.CreateClusterRequest{StateStore: ""}, true},
+		{"invalid vpcid", &model.ProvisionClusterRequest{VPCID: ""}, true},
+		{"invalid environment", &model.ProvisionClusterRequest{Environment: ""}, true},
+		{"invalid statestore", &model.ProvisionClusterRequest{StateStore: ""}, true},
 	}
 
 	for _, tc := range testCases {

--- a/terraform/aws/database-factory-postgresql/main.tf
+++ b/terraform/aws/database-factory-postgresql/main.tf
@@ -1,0 +1,56 @@
+terraform {
+  required_version = ">= 0.12"
+  backend "s3" {
+    region = "us-east-1"
+  }
+}
+
+
+provider "aws" {
+  region = var.region
+  alias  = "deployment"
+}
+
+
+module "rds_setup" {
+  source                           = "../modules/rds-aurora-postgresql"
+  vpc_id                           = var.vpc_id
+  db_id                            = var.db_id
+  environment                      = var.environment
+  port                             = var.port
+  name                             = "mattermost-cloud-${var.environment}-dbfactory"
+  engine                           = var.engine
+  engine_version                   = var.engine_version
+  username                         = var.username
+  password                         = var.password
+  final_snapshot_identifier_prefix = var.final_snapshot_identifier_prefix
+  skip_final_snapshot              = var.skip_final_snapshot
+  deletion_protection              = var.deletion_protection
+  backup_retention_period          = var.backup_retention_period
+  preferred_backup_window          = var.preferred_backup_window
+  preferred_maintenance_window     = var.preferred_maintenance_window
+  storage_encrypted                = var.storage_encrypted
+  apply_immediately                = var.apply_immediately
+  copy_tags_to_snapshot            = var.copy_tags_to_snapshot
+  enabled_cloudwatch_logs_exports  = var.enabled_cloudwatch_logs_exports
+  instance_type                    = var.instance_type
+  monitoring_interval              = var.monitoring_interval
+  performance_insights_enabled     = var.performance_insights_enabled
+  replica_scale_max                = var.replica_scale_max
+  replica_scale_min                = var.replica_scale_min
+  replica_min                      = var.replica_min
+  predefined_metric_type           = var.predefined_metric_type
+  replica_scale_cpu                = var.replica_scale_cpu
+  replica_scale_connections        = var.replica_scale_connections
+  replica_scale_in_cooldown        = var.replica_scale_in_cooldown
+  replica_scale_out_cooldown       = var.replica_scale_out_cooldown
+  max_postgresql_connections       = var.max_postgresql_connections
+  max_postgresql_connections_map   = var.max_postgresql_connections_map
+
+  tags = {
+    Owner       = "cloud-team"
+    Terraform   = "true"
+    Environment = var.environment
+    Purpose     = "provisioning"
+  }
+}

--- a/terraform/aws/database-factory-postgresql/variables.tf
+++ b/terraform/aws/database-factory-postgresql/variables.tf
@@ -1,0 +1,172 @@
+variable "vpc_id" {
+  default = ""
+  type    = string
+}
+
+variable "db_id" {
+  default = ""
+  type    = string
+}
+
+variable "environment" {
+  default = ""
+  type    = string
+}
+
+variable "port" {
+  default = "5432"
+  type    = string
+}
+
+variable "engine" {
+  default = "aurora-postgresql"
+  type    = string
+}
+
+variable "engine_version" {
+  default = "11.7"
+  type    = string
+}
+
+variable "username" {
+  default = "mmcloud"
+  type    = string
+}
+
+variable "password" {
+  default     = ""
+  type        = string
+  description = "If empty a random password will be created for each RDS Cluster and stored in AWS Secret Management."
+}
+
+variable "final_snapshot_identifier_prefix" {
+  default = "final"
+  type    = string
+}
+
+variable "skip_final_snapshot" {
+  default = false
+  type    = bool
+}
+
+variable "deletion_protection" {
+  default = true
+  type    = bool
+}
+
+variable "backup_retention_period" {
+  default = ""
+  type    = string
+}
+
+variable "preferred_backup_window" {
+  default = "02:00-03:00"
+  type    = string
+}
+
+variable "preferred_maintenance_window" {
+  default = "sun:05:00-sun:06:00"
+  type    = string
+}
+
+variable "storage_encrypted" {
+  default = true
+  type    = bool
+}
+
+variable "apply_immediately" {
+  default = true
+  type    = bool
+}
+
+variable "copy_tags_to_snapshot" {
+  default = true
+  type    = bool
+}
+
+variable "enabled_cloudwatch_logs_exports" {
+  default = ["postgresql"]
+  type    = list(string)
+}
+
+variable "instance_type" {
+  default = ""
+  type    = string
+}
+
+variable "monitoring_interval" {
+  default = 60
+  type    = number
+}
+
+variable "performance_insights_enabled" {
+  default = false
+  type    = bool
+}
+
+variable "replica_scale_max" {
+  default     = 15
+  type        = number
+  description = "Maximum number of replicas to scale up to."
+}
+
+variable "replica_scale_min" {
+  default = 1
+  type    = number
+}
+
+# Overwritten by database factory
+variable "replica_min" {
+  default     = 3
+  type        = number
+  description = "Number of replicas to deploy initially with the RDS Cluster. This is managed by the database factory app."
+}
+
+variable "predefined_metric_type" {
+  default = "RDSReaderAverageDatabaseConnections"
+  type    = string
+}
+
+variable "replica_scale_cpu" {
+  default     = 70
+  type        = number
+  description = "Needs to be set when predefined_metric_type is RDSReaderAverageCPUUtilization"
+}
+
+variable "replica_scale_connections" {
+  default     = 100000
+  type        = number
+  description = "Needs to be set when predefined_metric_type is RDSReaderAverageDatabaseConnections"
+}
+
+variable "replica_scale_in_cooldown" {
+  default     = 300
+  type        = number
+  description = "Cooldown in seconds before allowing further scaling operations after a scale in"
+}
+
+variable "replica_scale_out_cooldown" {
+  default     = 300
+  type        = number
+  description = "Cooldown in seconds before allowing further scaling operations after a scale out"
+}
+
+variable "max_postgresql_connections" {
+  default = ""
+  type = string
+}
+
+variable "max_postgresql_connections_map" {
+  default = {
+    "db.t3.medium" = "50000"
+    "db.r5.large" = "50000"
+    "db.r5.xlarge" = "120000"
+    "db.r5.2xlarge" = "200000"
+    "db.r5.4xlarge" = "250000"
+    "db.r5.8xlarge" = "255000"
+    "db.r5.12xlarge" = "262143"
+    "db.r5.16xlarge" = "262143"
+    "db.r5.24xlarge" = "262143"
+  }
+  type = map
+}

--- a/terraform/aws/database-factory-postgresql/variables.tf
+++ b/terraform/aws/database-factory-postgresql/variables.tf
@@ -100,7 +100,7 @@ variable "monitoring_interval" {
 }
 
 variable "performance_insights_enabled" {
-  default = false
+  default = true
   type    = bool
 }
 
@@ -133,6 +133,7 @@ variable "replica_scale_cpu" {
   description = "Needs to be set when predefined_metric_type is RDSReaderAverageCPUUtilization"
 }
 
+# NOT IN USE. Currently the 50% of max_connections parameter is set as a limit.
 variable "replica_scale_connections" {
   default     = 100000
   type        = number

--- a/terraform/aws/database-factory/main.tf
+++ b/terraform/aws/database-factory/main.tf
@@ -44,6 +44,8 @@ module "rds_setup" {
   replica_scale_connections        = var.replica_scale_connections
   replica_scale_in_cooldown        = var.replica_scale_in_cooldown
   replica_scale_out_cooldown       = var.replica_scale_out_cooldown
+  # Added for compatibility
+  max_postgresql_connections       = var.max_postgresql_connections
 
   tags = {
     Owner       = "cloud-team"

--- a/terraform/aws/database-factory/variables.tf
+++ b/terraform/aws/database-factory/variables.tf
@@ -150,4 +150,6 @@ variable "replica_scale_out_cooldown" {
   description = "Cooldown in seconds before allowing further scaling operations after a scale out"
 }
 
-
+variable "max_postgresql_connections" {
+  type = string
+}

--- a/terraform/aws/modules/rds-aurora-postgresql/variables.tf
+++ b/terraform/aws/modules/rds-aurora-postgresql/variables.tf
@@ -1,0 +1,65 @@
+variable "vpc_id" {}
+
+variable "db_id" {}
+
+variable "port" {}
+
+variable "environment" {}
+
+variable "name" {}
+
+variable "engine" {}
+
+variable "engine_version" {}
+
+variable "username" {}
+
+variable "password" {}
+
+variable "final_snapshot_identifier_prefix" {}
+
+variable "skip_final_snapshot" {}
+
+variable "deletion_protection" {}
+
+variable "backup_retention_period" {}
+
+variable "preferred_backup_window" {}
+
+variable "preferred_maintenance_window" {}
+
+variable "storage_encrypted" {}
+
+variable "apply_immediately" {}
+
+variable "copy_tags_to_snapshot" {}
+
+variable "enabled_cloudwatch_logs_exports" {}
+
+variable "tags" {}
+
+variable "instance_type" {}
+
+variable "monitoring_interval" {}
+
+variable "performance_insights_enabled" {}
+
+variable "replica_scale_max" {}
+
+variable "replica_scale_min" {}
+
+variable "replica_min" {}
+
+variable "predefined_metric_type" {}
+
+variable "replica_scale_cpu" {}
+
+variable "replica_scale_connections" {}
+
+variable "replica_scale_in_cooldown" {}
+
+variable "replica_scale_out_cooldown" {}
+
+variable "max_postgresql_connections" {}
+
+variable "max_postgresql_connections_map" {}

--- a/terraform/aws/modules/rds-aurora/variables.tf
+++ b/terraform/aws/modules/rds-aurora/variables.tf
@@ -60,4 +60,4 @@ variable "replica_scale_in_cooldown" {}
 
 variable "replica_scale_out_cooldown" {}
 
-
+variable "max_postgresql_connections" {}


### PR DESCRIPTION
#### Summary
With this PR:

- PostgreSQL support is added.
- API flags are added to:
  - Set the DB engine.
  - Set max number of connections in the database parameter group.
  - Set the number of initial replicas
- Create cluster API call is changed to provision cluster. Provisioning of cluster is used for both new DB clusters and update of existing ones.
- An automatic calculation of max connections is done based on instance type.
- Performance insights support is added for PostgreSQL clusters.
- Terraform version update to 0.12.29

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27340

#### Release Note

```release-note
- PostgreSQL support is added.
- API flags are added to:
  - Set the DB engine.
  - Set max number of connections in the database parameter group.
  - Set the number of initial replicas
- Create cluster API call is changed to provision cluster. Provisioning of cluster is used for both new DB clusters and update of existing ones.
- An automatic calculation of max connections is done based on instance type.
- Performance insights support is added for PostgreSQL clusters.
- Terraform version update to 0.12.29.
```
