### PR TITLE
[MM-28856] Adding custom metric for database Cloudwatch alarms.

### DIFF
--- a/terraform/aws/database-factory-postgresql/main.tf
+++ b/terraform/aws/database-factory-postgresql/main.tf
@@ -46,6 +46,9 @@ module "rds_setup" {
   replica_scale_out_cooldown       = var.replica_scale_out_cooldown
   max_postgresql_connections       = var.max_postgresql_connections
   max_postgresql_connections_map   = var.max_postgresql_connections_map
+  ram_memory_bytes                 = var.ram_memory_bytes
+  memory_cache_proportion          = var.memory_cache_proportion
+  memory_alarm_limit               = var.memory_alarm_limit
 
   tags = {
     Owner       = "cloud-team"

--- a/terraform/aws/database-factory-postgresql/variables.tf
+++ b/terraform/aws/database-factory-postgresql/variables.tf
@@ -171,3 +171,31 @@ variable "max_postgresql_connections_map" {
   }
   type = map
 }
+
+variable "ram_memory_bytes" {
+  default = {
+    "db.t3.medium" = "4294967296"
+    "db.r5.large" = "17179869184"
+    "db.r5.xlarge" = "34359738368"
+    "db.r5.2xlarge" = "68719476736"
+    "db.r5.4xlarge" = "137438953472"
+    "db.r5.8xlarge" = "274877906944"
+    "db.r5.12xlarge" = "412316860416"
+    "db.r5.16xlarge" = "549755813888"
+    "db.r5.24xlarge" = "824633720832"
+  }
+  type = map
+  description = "The RAM memory of each instance type in Bytes. A change in this variable should be reflected in database factory vertical scaling main.go as well."
+}
+
+variable "memory_alarm_limit" {
+  default = "100000000"
+  description = "Limit to trigger memory alarm. Number in Bytes (100MB)"
+  type = string
+}
+
+variable "memory_cache_proportion" {
+  default = 0.75
+  description = "Proportion of memory that is used for cache. By default it is 75%. A change in this variable should be reflected in database factory vertical scaling main.go as well."
+  type = number
+}

--- a/terraform/aws/modules/rds-aurora-postgresql/variables.tf
+++ b/terraform/aws/modules/rds-aurora-postgresql/variables.tf
@@ -63,3 +63,9 @@ variable "replica_scale_out_cooldown" {}
 variable "max_postgresql_connections" {}
 
 variable "max_postgresql_connections_map" {}
+
+variable "ram_memory_bytes" {}
+
+variable "memory_cache_proportion" {}
+
+variable "memory_alarm_limit" {}


### PR DESCRIPTION
#### Summary
Adding custom metric for database Cloudwatch alarms to take into account memory cache in calculation. This will solve the problem that current FreeMemory metric shows very low numbers of memory without taking into account a 75% of cache used.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28856

#### Release Note

```release-note
- Adding custom metric for database Cloudwatch alarms to take into account memory cache in calculation
```
