### PR TITLE
[MM 30946] Database factory fixes and improvements. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DOCKER_BUILD_IMAGE = golang:1.14.1
 DOCKER_BASE_IMAGE = alpine:3.11
 
 ## Tool Versions
-TERRAFORM_VERSION=0.12.29
+TERRAFORM_VERSION=0.13.5
 
 ################################################################################
 

--- a/terraform/aws/database-factory-postgresql/main.tf
+++ b/terraform/aws/database-factory-postgresql/main.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
   backend "s3" {
     region = "us-east-1"
+  }
+  required_providers {
+    aws = "~> 3.17.0"
   }
 }
 

--- a/terraform/aws/database-factory-postgresql/variables.tf
+++ b/terraform/aws/database-factory-postgresql/variables.tf
@@ -65,7 +65,7 @@ variable "preferred_backup_window" {
 }
 
 variable "preferred_maintenance_window" {
-  default = "sun:05:00-sun:06:00"
+  default = "sat:07:00-sat:08:00"
   type    = string
 }
 

--- a/terraform/aws/database-factory-postgresql/variables.tf
+++ b/terraform/aws/database-factory-postgresql/variables.tf
@@ -24,7 +24,7 @@ variable "engine" {
 }
 
 variable "engine_version" {
-  default = "11.7"
+  default = "11.8"
   type    = string
 }
 
@@ -159,15 +159,15 @@ variable "max_postgresql_connections" {
 
 variable "max_postgresql_connections_map" {
   default = {
-    "db.t3.medium" = "50000"
-    "db.r5.large" = "50000"
-    "db.r5.xlarge" = "120000"
-    "db.r5.2xlarge" = "200000"
-    "db.r5.4xlarge" = "250000"
-    "db.r5.8xlarge" = "255000"
-    "db.r5.12xlarge" = "262143"
-    "db.r5.16xlarge" = "262143"
-    "db.r5.24xlarge" = "262143"
+    "db.t3.medium" = "415"
+    "db.r5.large" = "1675"
+    "db.r5.xlarge" = "3355"
+    "db.r5.2xlarge" = "6710"
+    "db.r5.4xlarge" = "13425"
+    "db.r5.8xlarge" = "26855"
+    "db.r5.12xlarge" = "40285"
+    "db.r5.16xlarge" = "53715"
+    "db.r5.24xlarge" = "80575"
   }
   type = map
 }

--- a/terraform/aws/database-factory/main.tf
+++ b/terraform/aws/database-factory/main.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
   backend "s3" {
     region = "us-east-1"
+  }
+  required_providers {
+    aws = "~> 3.17.0"
   }
 }
 

--- a/terraform/aws/modules/rds-aurora-postgresql/main.tf
+++ b/terraform/aws/modules/rds-aurora-postgresql/main.tf
@@ -123,7 +123,7 @@ resource "aws_appautoscaling_policy" "autoscaling_read_replica_count" {
 
     scale_in_cooldown  = var.replica_scale_in_cooldown
     scale_out_cooldown = var.replica_scale_out_cooldown
-    target_value       = var.predefined_metric_type == "RDSReaderAverageCPUUtilization" ? var.replica_scale_cpu : tonumber(local.max_connections)/2
+    target_value       = var.predefined_metric_type == "RDSReaderAverageCPUUtilization" ? var.replica_scale_cpu : tonumber(local.max_connections)*0.6
   }
 
   depends_on = [aws_appautoscaling_target.read_replica_count]


### PR DESCRIPTION
#### Summary
- Use default AWS max connections
- Update Postgres to 11.8
- Fix autoscaling calculation.
- Upgrade to Terraform 0.13 and AWS provider 3.17

#### Ticket Link
Otherwise, link the JIRA ticket.
- https://mattermost.atlassian.net/browse/MM-30946
- https://mattermost.atlassian.net/browse/MM-30947
- https://mattermost.atlassian.net/browse/MM-30968

#### Release Note

```release-note
- Use default AWS max connections
- Update Postgres to 11.8
- Fix autoscaling calculation.
- Upgrade to Terraform 0.13 and AWS provider 3.17
```
