### PR TITLE
Add random_page_cost param custom value

### DIFF
--- a/terraform/aws/database-factory-postgresql/main.tf
+++ b/terraform/aws/database-factory-postgresql/main.tf
@@ -55,6 +55,7 @@ module "rds_setup" {
   tcp_keepalives_count             = var.tcp_keepalives_count
   tcp_keepalives_idle              = var.tcp_keepalives_idle
   tcp_keepalives_interval          = var.tcp_keepalives_interval
+  random_page_cost                 = var.random_page_cost
 
   tags = {
     Owner       = "cloud-team"

--- a/terraform/aws/database-factory-postgresql/variables.tf
+++ b/terraform/aws/database-factory-postgresql/variables.tf
@@ -206,6 +206,12 @@ variable "tcp_keepalives_count" {
   type = number
 }
 
+variable "random_page_cost" {
+  default = 1.1
+  description = "Sets the planner's estimate of the cost of a non-sequentially-fetched disk page. The default is 4.0. This value can be overridden for tables and indexes in a particular tablespace by setting the tablespace parameter of the same name."
+  type = number
+}
+
 variable "tcp_keepalives_idle" {
   default = 5
   description = "Time between issuing TCP keepalives.Specifies the amount of time with no network activity after which the operating system should send a TCP keepalive message to the client. If this value is specified without units, it is taken as seconds. A value of 0 (the default) selects the operating system's default."

--- a/terraform/aws/modules/rds-aurora-postgresql/main.tf
+++ b/terraform/aws/modules/rds-aurora-postgresql/main.tf
@@ -200,6 +200,11 @@ resource "aws_db_parameter_group" "db_parameter_group_postgresql" {
   }
 
   parameter {
+    name = "random_page_cost"
+    value = var.random_page_cost
+  }
+
+  parameter {
     name = "tcp_keepalives_count"
     value = var.tcp_keepalives_count
   }
@@ -232,6 +237,11 @@ resource "aws_rds_cluster_parameter_group" "cluster_parameter_group_postgresql" 
     apply_method = "pending-reboot"
     name         = "max_connections"
     value        = local.max_connections
+  }
+
+  parameter {
+    name = "random_page_cost"
+    value = var.random_page_cost
   }
 
   parameter {


### PR DESCRIPTION
Sets the planner's estimate of the cost of a non-sequentially-fetched
disk page. The default is 4.0. This value can be overridden for tables
and indexes in a particular tablespace by setting the tablespace
parameter of the same name (see sql-altertablespace).

Reducing this value relative to seq_page_cost will cause the system to
prefer index scans; raising it will make index scans look relatively
more expensive. You can raise or lower both values together to change
the importance of disk I/O costs relative to CPU costs, which are
described by the following parameters.
ref. https://postgresqlco.nf/doc/en/param/random_page_cost/

#### Summary
Add random_page_cost param custom value

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32388

#### Release Note
```release-note
Adds random_page_cost param custom value
```
