### PR TITLE
Bump version for postgresql from 11.8 to 11.9

### DIFF
--- a/terraform/aws/database-factory-postgresql/variables.tf
+++ b/terraform/aws/database-factory-postgresql/variables.tf
@@ -24,7 +24,7 @@ variable "engine" {
 }
 
 variable "engine_version" {
-  default = "11.8"
+  default = "11.9"
   type    = string
 }
 


### PR DESCRIPTION
#### Summary
The databases has been auto-upgraded to 11.9 so we need to follow up
and keep the factory code with the latest version in order to avoid
destroying any resource as the version bump in terraform means recreate
the resource.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34230


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Bump version in terraform for Postgres from 11.8 to 11.9
```
