### PR TITLE
[MM-36118] Add functionality in Database Factory to create RDS multitenant db clusters for dbproxy usage.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -38,6 +38,7 @@ func initCluster(apiRouter *mux.Router, context *Context) {
 //     "dbEngine: postgresql",
 //     "maxConnections": "150000"
 //     "replicas": "3"
+//     "dbProxy": true
 // }
 func handleProvisionDBCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 	provisionClusterRequest, err := model.NewProvisionClusterRequestFromReader(r.Body)
@@ -58,6 +59,7 @@ func handleProvisionDBCluster(c *Context, w http.ResponseWriter, r *http.Request
 		DBEngine:              provisionClusterRequest.DBEngine,
 		MaxConnections:        provisionClusterRequest.MaxConnections,
 		Replicas:              provisionClusterRequest.Replicas,
+		DBProxy:               provisionClusterRequest.DBProxy,
 	}
 
 	go dbfactory.InitProvisionCluster(&cluster)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -49,6 +49,7 @@ func TestProvisionCluster(t *testing.T) {
 			DBEngine:              "postgresql",
 			MaxConnections:        "150000",
 			Replicas:              "3",
+			DBProxy:               true,
 		})
 		require.EqualError(t, err, "failed with status code 400")
 	})
@@ -64,6 +65,7 @@ func TestProvisionCluster(t *testing.T) {
 			DBEngine:              "postgresql",
 			MaxConnections:        "150000",
 			Replicas:              "3",
+			DBProxy:               true,
 		})
 		require.EqualError(t, err, "failed with status code 400")
 	})
@@ -79,6 +81,7 @@ func TestProvisionCluster(t *testing.T) {
 			DBEngine:              "postgresql",
 			MaxConnections:        "150000",
 			Replicas:              "3",
+			DBProxy:               true,
 		})
 		require.EqualError(t, err, "failed with status code 400")
 	})
@@ -95,6 +98,7 @@ func TestProvisionCluster(t *testing.T) {
 			DBEngine:              "mysql",
 			MaxConnections:        "100000",
 			Replicas:              "2",
+			DBProxy:               false,
 		})
 		require.NoError(t, err)
 		require.Equal(t, "vpc-12345678", cluster.VPCID)
@@ -107,5 +111,6 @@ func TestProvisionCluster(t *testing.T) {
 		require.Equal(t, "mysql", cluster.DBEngine)
 		require.Equal(t, "100000", cluster.MaxConnections)
 		require.Equal(t, "2", cluster.Replicas)
+		require.Equal(t, false, cluster.DBProxy)
 	})
 }

--- a/cmd/dbfactory/cluster.go
+++ b/cmd/dbfactory/cluster.go
@@ -29,6 +29,7 @@ func init() {
 	clusterProvisionCmd.Flags().String("db-engine", "postgresql", "The database engine. Can be mysql or postgresql")
 	clusterProvisionCmd.Flags().String("max-connections", "auto", "The max connections allowed in the DB cluster. This is applicable only to PostgreSQL engine")
 	clusterProvisionCmd.Flags().String("replicas", "3", "The total number of write/read replicas.")
+	clusterProvisionCmd.Flags().Bool("dbproxy", true, "If enabled the multitenant DB cluster will be used with a DB proxy.")
 
 	clusterCmd.AddCommand(clusterProvisionCmd)
 
@@ -63,6 +64,7 @@ var clusterProvisionCmd = &cobra.Command{
 		dbEngine, _ := command.Flags().GetString("db-engine")
 		maxConnections, _ := command.Flags().GetString("max-connections")
 		replicas, _ := command.Flags().GetString("replicas")
+		dbProxy, _ := command.Flags().GetBool("dbproxy")
 
 		cluster, err := client.ProvisionCluster(&model.ProvisionClusterRequest{
 			VPCID:                 vpcID,
@@ -75,6 +77,7 @@ var clusterProvisionCmd = &cobra.Command{
 			DBEngine:              dbEngine,
 			MaxConnections:        maxConnections,
 			Replicas:              replicas,
+			DBProxy:               dbProxy,
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to provision RDS cluster")

--- a/internal/tools/terraform/plan.go
+++ b/internal/tools/terraform/plan.go
@@ -41,6 +41,13 @@ func (c *Cmd) Plan(cluster *model.Cluster) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to transform replicas string to integer")
 	}
+
+	var multitenantTag string
+	if cluster.DBProxy {
+		multitenantTag = "multitenant-rds-dbproxy"
+	} else {
+		multitenantTag = "multitenant-rds"
+	}
 	_, _, err = c.run(
 		"plan",
 		arg("input", "false"),
@@ -51,6 +58,7 @@ func (c *Cmd) Plan(cluster *model.Cluster) error {
 		arg("var", fmt.Sprintf("backup_retention_period=%s", cluster.BackupRetentionPeriod)),
 		arg("var", fmt.Sprintf("max_postgresql_connections=%s", cluster.MaxConnections)),
 		arg("var", fmt.Sprintf("replica_min=%d", replicas)),
+		arg("var", fmt.Sprintf("multitenant_tag=%s", multitenantTag)),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to invoke terraform plan")
@@ -65,6 +73,13 @@ func (c *Cmd) Apply(cluster *model.Cluster) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to transform replicas string to integer")
 	}
+
+	var multitenantTag string
+	if cluster.DBProxy {
+		multitenantTag = "multitenant-rds-dbproxy"
+	} else {
+		multitenantTag = "multitenant-rds"
+	}
 	_, _, err = c.run(
 		"apply",
 		arg("input", "false"),
@@ -75,6 +90,7 @@ func (c *Cmd) Apply(cluster *model.Cluster) error {
 		arg("var", fmt.Sprintf("backup_retention_period=%s", cluster.BackupRetentionPeriod)),
 		arg("var", fmt.Sprintf("max_postgresql_connections=%s", cluster.MaxConnections)),
 		arg("var", fmt.Sprintf("replica_min=%d", replicas)),
+		arg("var", fmt.Sprintf("multitenant_tag=%s", multitenantTag)),
 		arg("auto-approve"),
 	)
 	if err != nil {

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -17,6 +17,7 @@ type Cluster struct {
 	DBEngine              string
 	MaxConnections        string
 	Replicas              string
+	DBProxy               bool
 }
 
 // ClusterFromReader decodes a json-encoded cluster from the given io.Reader.

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -20,6 +20,7 @@ type ProvisionClusterRequest struct {
 	DBEngine              string `json:"dbEngine"`
 	MaxConnections        string `json:"maxConnections,omitempty"`
 	Replicas              string `json:"replicas"`
+	DBProxy               bool   `json:"dbProxy"`
 }
 
 // NewProvisionClusterRequestFromReader decodes the request and returns after validation and setting the defaults.

--- a/terraform/aws/database-factory-postgresql/main.tf
+++ b/terraform/aws/database-factory-postgresql/main.tf
@@ -56,6 +56,7 @@ module "rds_setup" {
   tcp_keepalives_idle              = var.tcp_keepalives_idle
   tcp_keepalives_interval          = var.tcp_keepalives_interval
   random_page_cost                 = var.random_page_cost
+  multitenant_tag                  = var.multitenant_tag
 
   tags = {
     Owner       = "cloud-team"

--- a/terraform/aws/database-factory-postgresql/variables.tf
+++ b/terraform/aws/database-factory-postgresql/variables.tf
@@ -133,6 +133,12 @@ variable "replica_scale_cpu" {
   description = "Needs to be set when predefined_metric_type is RDSReaderAverageCPUUtilization"
 }
 
+variable "multitenant_tag" {
+  default     = ""
+  type        = string
+  description = "The tag that will be applied and identify the type of multitenant DB cluster(multitenant-rds-dbproxy or multitenant-rds)."
+}
+
 # NOT IN USE. Currently the 50% of max_connections parameter is set as a limit.
 variable "replica_scale_connections" {
   default     = 100000

--- a/terraform/aws/modules/rds-aurora-postgresql/main.tf
+++ b/terraform/aws/modules/rds-aurora-postgresql/main.tf
@@ -60,7 +60,7 @@ resource "aws_rds_cluster" "provisioning_rds_cluster" {
       "Counter"               = 0,
       "MultitenantDatabaseID" = format("rds-cluster-multitenant-%s-%s", split("-", var.vpc_id)[1], local.database_id),
       "VpcID"                 = var.vpc_id,
-      "DatabaseType"          = "multitenant-rds",
+      "DatabaseType"          = var.multitenant_tag,
       "MattermostCloudInstallationDatabase" = "PostgreSQL/Aurora"
     },
     var.tags
@@ -153,7 +153,7 @@ resource "aws_cloudwatch_metric_alarm" "db_instances_alarm_cpu" {
   statistic                 = "Average"
   threshold                 = "70"
   alarm_description         = "This metric monitors RDS DB Instance cpu utilization"
-  actions_enabled           = true  
+  actions_enabled           = true
   alarm_actions             = [data.aws_sns_topic.horizontal_scaling_sns_topic.arn]
   dimensions                = {DBInstanceIdentifier = aws_rds_cluster_instance.provisioning_rds_db_instance[count.index].identifier}
 }
@@ -183,7 +183,7 @@ resource "aws_cloudwatch_metric_alarm" "db_instances_alarm_memory" {
     }
     return_data = "false"
   }
-  actions_enabled           = true  
+  actions_enabled           = true
   alarm_actions             = [data.aws_sns_topic.horizontal_scaling_sns_topic.arn]
 }
 

--- a/terraform/aws/modules/rds-aurora-postgresql/variables.tf
+++ b/terraform/aws/modules/rds-aurora-postgresql/variables.tf
@@ -78,3 +78,4 @@ variable "tcp_keepalives_idle" {}
 
 variable "tcp_keepalives_interval" {}
 
+variable "multitenant_tag" {}


### PR DESCRIPTION
#### Summary
-Add functionality in Database Factory to create RDS multitenant db clusters for dbproxy usage

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36118

#### Release Note
```release-note
- Add functionality in Database Factory to create RDS multitenant db clusters for dbproxy usage
```
