### PR TITLE
Add a cost allocation tag to postgres instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 
 coverage.out
 .vscode
+.idea
 build/_output/


### PR DESCRIPTION

#### Summary
If this commit applied the postgres instances will have a tag that is used for cost_allocation


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36254

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add `multitenant-rds` cost allocation tag to postgres multi-tenant instances.
```
