### PR TITLE
Automate release cut, release-notes 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,15 @@ jobs:
         path: gl-container-scanning-report.json
         destination: security-scan
 
+  release:
+    executor: default
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo apt update && sudo apt install hub git
+            GO111MODULE=on go get k8s.io/release/cmd/release-notes
+            make release
 workflows:
   version: 2
   ci-build:
@@ -148,3 +157,12 @@ workflows:
             only: /^v.*/
           branches:
             ignore: /.*/
+
+  publish-github-release:
+    jobs:
+      - release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -8,18 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - shell: bash
+      - run: make notify
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          REPO=$(echo $GITHUB_CONTEXT | jq -r '.repository')
-          TAGVERSION=$(echo $GITHUB_CONTEXT | jq -r '.event.release.tag_name')
-          TAGURL=$(echo $GITHUB_CONTEXT | jq -r '.event.release.html_url')
-          BODY=$(echo $GITHUB_CONTEXT | jq -r '.event.release.body' | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')
-
-          echo "{\"username\":\"Cloud Bot Notify\",\"icon_url\":\"https://www.mattermost.org/wp-content/uploads/2016/04/icon.png\",\"text\":\"# **New Release for $REPO** - Release [$TAGVERSION]($TAGURL)\n $BODY\"}" > mattermost.json
-          cat mattermost.json
-
       - uses: mattermost/action-mattermost-notify@1.0.2
         env:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}

--- a/Makefile
+++ b/Makefile
@@ -100,3 +100,15 @@ setup-test:
 test:
 	@echo Running tests
 	go test ./... -v -covermode=count -coverprofile=coverage.out
+
+# Cut a release
+.PHONY: release
+release:
+	@echo Cut a release
+	sh ./scripts/release.sh
+
+# Notify a release publish
+.PHONY: notify
+notify:
+	@echo Notify a release publish
+	sh ./scripts/notify.sh

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+# Usage: sh notify.sh
+
+# Stop script on first error
+set -xe
+
+REPO=$(echo $GITHUB_CONTEXT | jq -r '.repository')
+TAGVERSION=$(echo $GITHUB_CONTEXT | jq -r '.event.release.tag_name')
+TAGURL=$(echo $GITHUB_CONTEXT | jq -r '.event.release.html_url')
+BODY=$(echo $GITHUB_CONTEXT | jq -r '.event.release.body' | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')
+echo "{\"username\":\"Cloud Bot Notify\",\"icon_url\":\"https://www.mattermost.org/wp-content/uploads/2016/04/icon.png\",\"text\":\"# **New Release for $REPO** - Release [$TAGVERSION]($TAGURL)\n $BODY\"}" > mattermost.json
+cat mattermost.json

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+# Usage: sh release.sh
+# Note: To run this script locally you need to export environment variables CIRCLE_TAG and GITHUB_TOKEN.
+
+# Stop script on first error
+set -xe
+
+FUTURE_RELEASE_SHA=$(hub rev-parse HEAD)
+LATEST_RELEASE=$(hub release | head -n 1)
+# The following fixes the script to work in the case that there isn't a previous release in place.
+if [[ "$LATEST_RELEASE" == "" ]]; then
+  LATEST_RELEASE=$(git log --pretty=%H | tail -n 1)
+fi
+LATEST_RELEASE_SHA=$(hub rev-parse "${LATEST_RELEASE}")
+LATEST_RELEASE_NEXT_COMMIT_SHA=$(hub log "${LATEST_RELEASE}"..HEAD --oneline --pretty=%H | tail -n1)
+mkdir -p ./build/_output/docs/
+release-notes --org mattermost --repo mattermost-cloud-database-factory --start-sha "${LATEST_RELEASE_NEXT_COMMIT_SHA}" --end-sha "${FUTURE_RELEASE_SHA}"  --output ./build/_output/docs/relnote.md --required-author "" --branch main
+cat ./build/_output/docs/relnote.md | sed '/docs.k8s.io/ d' | sed -e "s/\# Release notes for/${CIRCLE_TAG}/g" | sed -e "s/Changelog since/Changelog since ${LATEST_RELEASE}/g"> ./build/_output/docs/relnote_parsed.md
+echo "\n" >> ./build/_output/docs/relnote_parsed.md
+echo "The image for this release is \`docker.io/mattermost/mattermost-cloud-database-factory:${CIRCLE_TAG}\`" >> ./build/_output/docs/relnote_parsed.md
+echo "\n" >> ./build/_output/docs/relnote_parsed.md
+echo "_Thanks to all our contributors!_" >> ./build/_output/docs/relnote_parsed.md
+mv ./build/_output/docs/relnote_parsed.md ./build/_output/docs/relnote.md
+
+hub release create -d -F ./build/_output/docs/relnote.md ${CIRCLE_TAG}
+rm -rf ./build/_output/


### PR DESCRIPTION

If this commit applied no manual actions will be needed on release cut process apart from tag push
Issue: MM-36354

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Automate release cut, release-notes 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36354

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Automates release cut.
```
