### PR TITLE
Upgrade terraform version to 0.14.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DOCKER_BUILD_IMAGE = golang:1.14.1
 DOCKER_BASE_IMAGE = alpine:3.11
 
 ## Tool Versions
-TERRAFORM_VERSION=0.13.5
+TERRAFORM_VERSION=0.14.5
 
 ################################################################################
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For the configuration Terraform templates and modules are being used, preconfigu
 ### Environment Setup
 
 1. Install [Go](https://golang.org/doc/install)
-2. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) version v0.13.5
+2. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) version v0.14.5
 3. Specify the region in your AWS config, e.g. `~/.aws/config`:
 ```
 [profile mm-cloud]

--- a/terraform/aws/database-factory-postgresql/main.tf
+++ b/terraform/aws/database-factory-postgresql/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14.5"
   backend "s3" {
     region = "us-east-1"
   }

--- a/terraform/aws/database-factory/main.tf
+++ b/terraform/aws/database-factory/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14.5"
   backend "s3" {
     region = "us-east-1"
   }


### PR DESCRIPTION
After this commit applied dbfactory will use 0.14.5 terraform version.
Issue: MM-36454

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Upgrade terraform version to 0.14.5

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36454

#### Release Note

```release-note
Upgrade terraform version to 0.14.5
```
