### PR TITLE
[CLD-4991]: Add support to log_min_duration_statement param

### DIFF
--- a/terraform/aws/database-factory-postgresql/main.tf
+++ b/terraform/aws/database-factory-postgresql/main.tf
@@ -56,7 +56,7 @@ module "rds_setup" {
   creation_snapshot_arn            = var.creation_snapshot_arn
   connections_safety_percentage    = var.connections_safety_percentage
   enable_devops_guru               = var.enable_devops_guru
-
+  log_min_duration_statement       = var.log_min_duration_statement
   tags = {
     Owner       = "cloud-team"
     Terraform   = "true"

--- a/terraform/aws/database-factory-postgresql/variables.tf
+++ b/terraform/aws/database-factory-postgresql/variables.tf
@@ -261,3 +261,9 @@ variable "enable_devops_guru" {
   type        = string
   description = "Set it to true will enable AWS Devops Guru service for DB instances within the cluster."
 }
+
+variable "log_min_duration_statement" {
+  default     = -1
+  type        = number
+  description = "The duration of each completed statement to be logged."
+}

--- a/terraform/aws/modules/rds-aurora-postgresql/README.md
+++ b/terraform/aws/modules/rds-aurora-postgresql/README.md
@@ -56,6 +56,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the environment which will deploy to and will be added as a tag | `string` | n/a | yes |
 | <a name="input_final_snapshot_identifier_prefix"></a> [final\_snapshot\_identifier\_prefix](#input\_final\_snapshot\_identifier\_prefix) | The prefix name of your final DB snapshot when this DB instance is deleted | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The instance type of the RDS instance | `string` | n/a | yes |
+| <a name="input_log_min_duration_statement"></a> [log\_min\_duration\_statement](#input\_log\_min\_duration\_statement) | The duration of each completed statement to be logged. | `number` | n/a | yes |
 | <a name="input_memory_alarm_limit"></a> [memory\_alarm\_limit](#input\_memory\_alarm\_limit) | Limit to trigger memory alarm. Number in Bytes (100MB) | `string` | n/a | yes |
 | <a name="input_memory_cache_proportion"></a> [memory\_cache\_proportion](#input\_memory\_cache\_proportion) | Proportion of memory that is used for cache. By default it is 75%. A change in this variable should be reflected in database factory vertical scaling main.go as well. | `number` | n/a | yes |
 | <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance | `number` | n/a | yes |

--- a/terraform/aws/modules/rds-aurora-postgresql/main.tf
+++ b/terraform/aws/modules/rds-aurora-postgresql/main.tf
@@ -99,7 +99,7 @@ resource "aws_rds_cluster_instance" "provisioning_rds_db_instance" {
       "MattermostCloudInstallationDatabase" = "PostgreSQL/Aurora"
     },
     var.tags,
-    [var.enable_devops_guru ? {"devops-guru-default" = "${aws_rds_cluster.provisioning_rds_cluster.cluster_identifier}-${count.index + 1}"} : null]...)
+    [var.enable_devops_guru ? {"devops-guru-default" = replace("${aws_rds_cluster.provisioning_rds_cluster.cluster_identifier}-${count.index + 1}", "/rds-cluster/", "rds-db-instance")} : null]...)
   lifecycle {
     ignore_changes = [
       instance_class,
@@ -207,6 +207,11 @@ resource "aws_db_parameter_group" "db_parameter_group_postgresql" {
     value = var.tcp_keepalives_interval
   }
 
+  parameter {
+    name  = "log_min_duration_statement"
+    value = var.environment == "prod" ? 2000 : var.log_min_duration_statement
+  }
+
   tags = merge(
     {
       "MattermostCloudInstallationDatabase" = "PostgreSQL/Aurora"
@@ -245,6 +250,11 @@ resource "aws_rds_cluster_parameter_group" "cluster_parameter_group_postgresql" 
   parameter {
     name  = "tcp_keepalives_interval"
     value = var.tcp_keepalives_interval
+  }
+
+    parameter {
+    name  = "log_min_duration_statement"
+    value = var.environment == "prod" ? 2000 : var.log_min_duration_statement
   }
 
   tags = merge(

--- a/terraform/aws/modules/rds-aurora-postgresql/variables.tf
+++ b/terraform/aws/modules/rds-aurora-postgresql/variables.tf
@@ -198,3 +198,8 @@ variable "enable_devops_guru" {
   type        = bool
   description = "Set it to true will enable AWS Devops Guru service for DB instances within the cluster."
 }
+
+variable "log_min_duration_statement" {
+  type        = number
+  description = "The duration of each completed statement to be logged."
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
During database sync with the current infrastructure, we encountered some manual changes to log_min_duration_statement parameter so this PR will allow Dbfactory to support it.

`-1` is the default value for the parameter. https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-LOG-MIN-DURATION-STATEMENT

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/CLD-4491


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
