### PR TITLE
[CLD-5827] Enable cloudwatch log exports for postgres and mysql clusters

### DIFF
--- a/terraform/aws/database-factory-postgresql/main.tf
+++ b/terraform/aws/database-factory-postgresql/main.tf
@@ -57,6 +57,7 @@ module "rds_setup" {
   enable_devops_guru               = var.enable_devops_guru
   log_min_duration_statement       = var.log_min_duration_statement
   allow_major_version_upgrade      = var.allow_major_version_upgrade
+  enabled_cloudwatch_logs_exports  = var.enabled_cloudwatch_logs_exports
   tags = {
     Owner       = "cloud-team"
     Terraform   = "true"

--- a/terraform/aws/database-factory-postgresql/variables.tf
+++ b/terraform/aws/database-factory-postgresql/variables.tf
@@ -243,10 +243,10 @@ variable "allow_major_version_upgrade" {
   default     = false
   type        = bool
   description = "Enable to allow major engine version upgrades when changing engine versions"
-} 
+}
 
 variable "enabled_cloudwatch_logs_exports" {
-   default     = ["postgresql"]
-   description = "Set of log types to enable for exporting to CloudWatch logs"
-   type        = list(string)
+  default     = ["postgresql"]
+  description = "Set of log types to enable for exporting to CloudWatch logs"
+  type        = list(string)
 }

--- a/terraform/aws/database-factory-postgresql/variables.tf
+++ b/terraform/aws/database-factory-postgresql/variables.tf
@@ -244,3 +244,9 @@ variable "allow_major_version_upgrade" {
   type        = bool
   description = "Enable to allow major engine version upgrades when changing engine versions"
 } 
+
+variable "enabled_cloudwatch_logs_exports" {
+   default     = ["postgresql"]
+   description = "Set of log types to enable for exporting to CloudWatch logs"
+   type        = list(string)
+}

--- a/terraform/aws/database-factory/main.tf
+++ b/terraform/aws/database-factory/main.tf
@@ -50,6 +50,7 @@ module "rds_setup" {
   replica_scale_out_cooldown       = var.replica_scale_out_cooldown
   creation_snapshot_arn            = var.creation_snapshot_arn
   multitenant_tag                  = var.multitenant_tag
+  enabled_cloudwatch_logs_exports  = var.enabled_cloudwatch_logs_exports
 
   # Added for compatibility
 

--- a/terraform/aws/database-factory/variables.tf
+++ b/terraform/aws/database-factory/variables.tf
@@ -179,7 +179,7 @@ variable "multitenant_tag" {
 }
 
 variable "enabled_cloudwatch_logs_exports" {
-   default     = ["audit", "error", "general", "slowquery"]
-   description = "Set of log types to enable for exporting to CloudWatch logs"
-   type        = list(string)
- }
+  default     = ["audit", "error", "general", "slowquery"]
+  description = "Set of log types to enable for exporting to CloudWatch logs"
+  type        = list(string)
+}

--- a/terraform/aws/database-factory/variables.tf
+++ b/terraform/aws/database-factory/variables.tf
@@ -177,3 +177,9 @@ variable "multitenant_tag" {
   type        = string
   description = "The tag that will be applied and identify the type of multitenant DB cluster(multitenant-rds-dbproxy or multitenant-rds)."
 }
+
+variable "enabled_cloudwatch_logs_exports" {
+   default     = ["audit", "error", "general", "slowquery"]
+   description = "Set of log types to enable for exporting to CloudWatch logs"
+   type        = list(string)
+ }

--- a/terraform/aws/modules/rds-aurora-postgresql/main.tf
+++ b/terraform/aws/modules/rds-aurora-postgresql/main.tf
@@ -293,6 +293,6 @@ resource "aws_rds_cluster_parameter_group" "cluster_parameter_group_postgresql" 
 }
 
 resource "aws_cloudwatch_log_group" "rds-cluster-log-group" {
-   name            = format("rds-cluster-multitenant-%s-%s/postgresql", split("-", var.vpc_id)[1], local.database_id)
-   depends_on = [aws_rds_cluster.provisioning_rds_cluster]
- }
+  name       = format("rds-cluster-multitenant-%s-%s/postgresql", split("-", var.vpc_id)[1], local.database_id)
+  depends_on = [aws_rds_cluster.provisioning_rds_cluster]
+}

--- a/terraform/aws/modules/rds-aurora-postgresql/main.tf
+++ b/terraform/aws/modules/rds-aurora-postgresql/main.tf
@@ -77,6 +77,7 @@ resource "aws_rds_cluster" "provisioning_rds_cluster" {
   copy_tags_to_snapshot            = var.copy_tags_to_snapshot
   snapshot_identifier              = var.creation_snapshot_arn == "" ? null : var.creation_snapshot_arn
   allow_major_version_upgrade      = var.allow_major_version_upgrade
+  enabled_cloudwatch_logs_exports  = var.enabled_cloudwatch_logs_exports
 
   tags = merge(
     {
@@ -290,3 +291,8 @@ resource "aws_rds_cluster_parameter_group" "cluster_parameter_group_postgresql" 
     create_before_destroy = true
   }
 }
+
+resource "aws_cloudwatch_log_group" "rds-cluster-log-group" {
+   name            = format("rds-cluster-multitenant-%s-%s/postgresql", split("-", var.vpc_id)[1], local.database_id)
+   depends_on = [aws_rds_cluster.provisioning_rds_cluster]
+ }

--- a/terraform/aws/modules/rds-aurora-postgresql/variables.tf
+++ b/terraform/aws/modules/rds-aurora-postgresql/variables.tf
@@ -187,9 +187,9 @@ variable "log_min_duration_statement" {
 variable "allow_major_version_upgrade" {
   type        = bool
   description = "Enable to allow major engine version upgrades when changing engine versions"
-} 
+}
 
 variable "enabled_cloudwatch_logs_exports" {
-   description = "Set of log types to enable for exporting to CloudWatch logs"
-   type        = list(string)
- }
+  description = "Set of log types to enable for exporting to CloudWatch logs"
+  type        = list(string)
+}

--- a/terraform/aws/modules/rds-aurora-postgresql/variables.tf
+++ b/terraform/aws/modules/rds-aurora-postgresql/variables.tf
@@ -188,3 +188,8 @@ variable "allow_major_version_upgrade" {
   type        = bool
   description = "Enable to allow major engine version upgrades when changing engine versions"
 } 
+
+variable "enabled_cloudwatch_logs_exports" {
+   description = "Set of log types to enable for exporting to CloudWatch logs"
+   type        = list(string)
+ }

--- a/terraform/aws/modules/rds-aurora/main.tf
+++ b/terraform/aws/modules/rds-aurora/main.tf
@@ -85,6 +85,7 @@ resource "aws_rds_cluster" "provisioning_rds_cluster" {
   db_cluster_parameter_group_name = "mattermost-provisioner-rds-cluster-pg"
   copy_tags_to_snapshot           = var.copy_tags_to_snapshot
   snapshot_identifier             = var.creation_snapshot_arn == "" ? null : var.creation_snapshot_arn
+  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
 
   tags = merge(
     {

--- a/terraform/aws/modules/rds-aurora/variables.tf
+++ b/terraform/aws/modules/rds-aurora/variables.tf
@@ -148,3 +148,8 @@ variable "creation_snapshot_arn" {
   description = "The ARN of the snapshot to create from"
   default     = ""
 }
+
+variable "enabled_cloudwatch_logs_exports" {
+   description = "Set of log types to enable for exporting to CloudWatch logs"
+   type        = list(string)
+ }

--- a/terraform/aws/modules/rds-aurora/variables.tf
+++ b/terraform/aws/modules/rds-aurora/variables.tf
@@ -150,6 +150,6 @@ variable "creation_snapshot_arn" {
 }
 
 variable "enabled_cloudwatch_logs_exports" {
-   description = "Set of log types to enable for exporting to CloudWatch logs"
-   type        = list(string)
- }
+  description = "Set of log types to enable for exporting to CloudWatch logs"
+  type        = list(string)
+}


### PR DESCRIPTION
#### Summary
- Enable cloudwatch log exports for postgres and mysql clusters

#### Release Note

```release-note
- Enable cloudwatch log exports for postgres and mysql clusters
```
